### PR TITLE
Add unzip to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM tomcat:8.5.42-jdk11-openjdk-slim
 LABEL Maintaner JamfDevops <devops@jamf.com>
 
 RUN apt-get update -qq && \
-	DEBIAN_FRONTEND=noninteractive apt-get install --ignore-missing --no-install-recommends -y jq curl && \
+	DEBIAN_FRONTEND=noninteractive apt-get install --ignore-missing --no-install-recommends -y jq curl unzip && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 	adduser --disabled-password --gecos '' tomcat && \
 	rm -rf /usr/local/tomcat/webapps && \


### PR DESCRIPTION
It seems that in the new tomcat image: 8.5.42-jdk11-openjdk-slim the unzip package isn't installed.
This results in an error when unpacking the ROOT.war