### PR TITLE
Update base image version to 8.5.51

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.5.42-jdk11-openjdk-slim
+FROM tomcat:8.5.51-jdk11-openjdk-slim
 
 LABEL Maintaner JamfDevops <devops@jamf.com>
 


### PR DESCRIPTION
JAMF sent out an email here with the following information:

> Apache Tomcat recently announced a security fix for a high-severity vulnerability in their product. Because Jamf Pro requires Apache Tomcat and security is of utmost importance, we are passing on the following information so that you can take steps to mitigate the vulnerability in your environment.

According to the Apache patch notes, [this vulnerability was patched in 8.5.51](http://tomcat.apache.org/security-8.html?mkt_tok=eyJpIjoiWm1JNE5UTTNORGRoWXpVNCIsInQiOiJhcTgreFlFMlVkYkRMN0lLc1ZRVUE2d3pzQVF3SmQycjZCRjNQdWVIb3VUOG5jZUlTbWpvNW43cVF6b2Nua0cxaEJYanp4WnJReURCQ0pJT2xUVGdTNERtY2sxdmdUNWVadmhmMjRNMnBhRHF4cFpyajlyeGQrYkNncXh1THFcLzEifQ%3D%3D#Fixed_in_Apache_Tomcat_8.5.51)

Simply updating the base image to match that.  Verified working just fine in prod cluster here with no other changes in functionality.