### PR TITLE
Bump Tomcat to 8.5.97

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TOMCAT_VERSION=8.5.90-jdk11
+ARG TOMCAT_VERSION=8.5.97-jdk11
 FROM tomcat:$TOMCAT_VERSION
 
 LABEL Maintainer JamfDevops <devops@jamf.com>


### PR DESCRIPTION
Jamf Pro 11.1.2 bumps the Tomcat-Version that's bundled in the Installer to 8.5.96 to mitigate a known vulnerability (CVE-2023-46589)