### PR TITLE
Update for Jamf Pro 11.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TOMCAT_VERSION=8.5.97-jdk11
+ARG TOMCAT_VERSION=9.0.85-jdk21
 FROM tomcat:$TOMCAT_VERSION
 
 LABEL Maintainer JamfDevops <devops@jamf.com>


### PR DESCRIPTION
Change Tomcat Version to 9.0.85 and Java Version to 21.
The changes result from the new recommended system requirements for Jamf Pro 11.3.