### PR TITLE
(configuration): setup the memcached.directory.timeToLiveSeconds property when MEMCACHED_HOST is defined

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -148,6 +148,7 @@ create_memcached_properties(){
   cat <<-EOF > ${WEBAPPS_DIR}/ROOT/WEB-INF/classes/dal/memcached.properties
 memcached.endpoints[0]=$MEMCACHED_HOST
 memcached.timeToLiveSeconds=120
+memcached.directory.timeToLiveSeconds=86400
 EOF
 }
 


### PR DESCRIPTION
Jamf fails to start with error `Time to live seconds must not be null` when configured to run in a clustered mode with memcached enabled (env var `MEMCACHED_HOST` is defined).

As per the documentation, the `memcached.directory.timeToLiveSeconds` must be set in the `memcached.properties` file.

Reference: https://learn.jamf.com/en-US/bundle/technical-articles/page/Troubleshooting_Caching_Configuration.html 