### PR TITLE
Update for Jamf Pro 11.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TOMCAT_VERSION=9.0.85-jdk21
+ARG TOMCAT_VERSION=10.1.28-jdk21
 FROM tomcat:$TOMCAT_VERSION
 
 LABEL Maintainer JamfDevops <devops@jamf.com>


### PR DESCRIPTION
Change Tomcat Version to 10.1.28
The changes result from the new system requirements for Jamf Pro 11.9.