### PR TITLE
Update for Jamf Pro 11.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TOMCAT_VERSION=10.1.42-jdk21
+ARG TOMCAT_VERSION=10.1.44-jdk21
 FROM tomcat:$TOMCAT_VERSION
 
 LABEL Maintainer JamfDevops <devops@jamf.com>


### PR DESCRIPTION
Change Tomcat Version to 10.1.44

The changes result from the new system requirements for Jamf Pro 11.20.2 resolving a known security vulnerability in a third-party library (CVE-2025-48989)