### PR TITLE
Update for Jamf Pro 11.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TOMCAT_VERSION=10.1.44-jdk21
+ARG TOMCAT_VERSION=10.1.49-jdk21
 FROM tomcat:$TOMCAT_VERSION
 
 LABEL Maintainer JamfDevops <devops@jamf.com>
@@ -14,7 +14,6 @@ RUN apt-get update -qq && \
 COPY startup.sh /startup.sh
 COPY log4j.stdout.replace /log4j.stdout.replace
 COPY log4j2.stdout.appenders.replace /log4j2.stdout.appenders.replace
-COPY log4j2.stdout.loggers.analytics.replace /log4j2.stdout.loggers.analytics.replace
 COPY log4j2.stdout.loggers.root.replace /log4j2.stdout.loggers.root.replace
 COPY log4j2.stdout.loggers.vpp.replace /log4j2.stdout.loggers.vpp.replace
 COPY server.template /jamfpro-config/server.template

--- a/configuration.sh
+++ b/configuration.sh
@@ -58,11 +58,9 @@ setup_stdout_logging() {
         echo_time "Add stdout logging to log4j2.xml file"
         sed -e '/<Appenders>/ {r /log4j2.stdout.appenders.replace
           d}' -i ${WEBAPPS_DIR}/ROOT/WEB-INF/classes/log4j2.xml
-        sed -e '/<Root level="info" includeLocation="false">/ {r /log4j2.stdout.loggers.root.replace
+        sed -e '/<AppenderRef ref="JAMF" \/>/ {r /log4j2.stdout.loggers.root.replace
           d}' -i ${WEBAPPS_DIR}/ROOT/WEB-INF/classes/log4j2.xml
-        sed -e '/<Logger name="com.jamfsoftware.analytics.file" level="info" additivity="false" includeLocation="false">/ {r /log4j2.stdout.loggers.analytics.replace
-          d}' -i ${WEBAPPS_DIR}/ROOT/WEB-INF/classes/log4j2.xml
-        sed -e '/<AppenderRef ref="JAMFVPP"\/>/ {r /log4j2.stdout.loggers.vpp.replace
+        sed -e '/<AppenderRef ref="JAMFVPP" \/>/ {r /log4j2.stdout.loggers.vpp.replace
           d}' -i ${WEBAPPS_DIR}/ROOT/WEB-INF/classes/log4j2.xml
       fi
     fi

--- a/log4j2.stdout.appenders.replace
+++ b/log4j2.stdout.appenders.replace
@@ -1,5 +1,5 @@
-    <Appenders>
-        <!--The appender for stdout logging-->
-        <Console name="Console" target="SYSTEM_OUT">
-          <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n"/>
-        </Console>
+        <Appenders>
+            <!--The appender for stdout logging-->
+            <Console name="Console" target="SYSTEM_OUT">
+              <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n"/>
+            </Console>

--- a/log4j2.stdout.loggers.analytics.replace
+++ b/log4j2.stdout.loggers.analytics.replace
@@ -1,2 +1,0 @@
-        <Logger name="com.jamfsoftware.analytics.file" level="info" additivity="false" includeLocation="false">
-            <AppenderRef ref="Console"/>

--- a/log4j2.stdout.loggers.root.replace
+++ b/log4j2.stdout.loggers.root.replace
@@ -1,2 +1,2 @@
-        <Root level="info" includeLocation="false">
-            <AppenderRef ref="Console"/>
+                    <AppenderRef ref="JAMF" />
+                    <AppenderRef ref="Console" />

--- a/log4j2.stdout.loggers.vpp.replace
+++ b/log4j2.stdout.loggers.vpp.replace
@@ -1,2 +1,2 @@
-            <AppenderRef ref="JAMFVPP"/>
-            <AppenderRef ref="Console"/>
+                    <AppenderRef ref="JAMFVPP" />
+                    <AppenderRef ref="Console" />


### PR DESCRIPTION
- Change Tomcat Version to 10.1.49
The changes result from the new system requirements for Jamf Pro 11.24.0.
- The log4j2.xml file was modified in Jamf Pro version 11.24.0. The script for changing the log settings was adjusted accordingly.

